### PR TITLE
Updated multipart dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tempdir = "0.3"
 
 [dependencies.multipart]
 features = ["server"]
-version = "0.7"
+version = "0.8"
 
 [dev-dependencies]
 maplit = "0.1"


### PR DESCRIPTION
Params uses multipart 0.7, as abonander/multipart#44 was resolved (depending on hyper 0.9), the a new version was released -- 0.8.

Fixes #26.
