### PR TITLE
Don't depend on default multipart features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "params"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Skyler Lipthay <skyler.lipthay@gmail.com>"]
 description = "A multi-source request parameters parser for Iron."
 readme = "README.md"
@@ -19,6 +19,7 @@ urlencoded = "0.4"
 tempdir = "0.3"
 
 [dependencies.multipart]
+default-features = false
 features = ["server"]
 version = "0.8"
 


### PR DESCRIPTION
The [default features](https://github.com/abonander/multipart/blob/master/Cargo.toml#L55) of multipart include hyper. That uses openssl 0.7. So params cannot be used with openssl 0.9:

    [dependencies]
    openssl = "0.9.1"
    params = "0.5.0"

This will [cause](http://stackoverflow.com/questions/40824435/using-both-git2-and-hyper-openssl-linked-more-than-once) an error message:

`error: native library openssl is being linked to by more than one version of the same package, but it can only be linked once; try updating or pinning your dependencies to ensure that this package only shows up once`

    openssl-sys v0.7.17
    openssl-sys v0.9.1

As params does not seem to require hyper, this PR removes the default features.

I also updated the version number - I'm not sure if I should.