### PR TITLE
Update dependency and fix clippy warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,19 @@ repository = "https://github.com/iron/params"
 documentation = "http://ironframework.io/doc/params/index.html"
 
 [dependencies]
-bodyparser = "0.5"
+bodyparser = "0.6"
 iron = "0.5"
 num = "0.1"
 plugin = "0.2"
-serde = { version = "0.8", optional = true }
-serde_json = "0.8"
+serde = { version = "0.9", optional = true }
+serde_json = "0.9"
 urlencoded = "0.5"
 tempdir = "0.3"
 
 [dependencies.multipart]
 default-features = false
 features = ["server"]
-version = "0.8"
+version = "0.12"
 
 [dev-dependencies]
 maplit = "0.1"

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -107,7 +107,7 @@ impl<T: FromValue> FromValue for Option<T> {
     fn from_value(value: &Value) -> Option<Option<T>> {
         match *value {
             Value::Null => Some(None),
-            _ => T::from_value(value).map(|result| Some(result)),
+            _ => T::from_value(value).map(Some),
         }
     }
 }


### PR DESCRIPTION
* bodyparser: 0.5 → 0.6
* serde: 0.8 → 0.9
* serde_json: 0.8 → 0.9
* multipart: 0.8 → 0.12

Fixes #29, #33.

Note: Since this crate depends on `urlencoded`, which depends on `bodyparser = "0.5"`, please also check iron/urlencoded#69.