### PR TITLE
Updates for iron 0.6 and serde 1.0, bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,3 @@ tempdir = "0.3"
 default-features = false
 features = ["server"]
 version = "0.12"
-
-[dev-dependencies]
-maplit = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/iron/params"
 documentation = "http://ironframework.io/doc/params/index.html"
 
 [dependencies]
-bodyparser = "0.6"
+bodyparser = "0.7"
 iron = "0.5"
 num = "0.1"
 plugin = "0.2"
-serde = { version = "0.9", optional = true }
-serde_json = "0.9"
+serde = { version = "1", optional = true }
+serde_json = "1"
 urlencoded = "0.5"
 tempdir = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "params"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Skyler Lipthay <skyler.lipthay@gmail.com>"]
 description = "A multi-source request parameters parser for Iron."
 readme = "README.md"
@@ -9,16 +9,16 @@ repository = "https://github.com/iron/params"
 documentation = "http://ironframework.io/doc/params/index.html"
 
 [dependencies]
-bodyparser = "0.7"
-iron = "0.5"
+bodyparser = "0.8"
+iron = ">=0.5, <0.7"
 num = "0.1"
 plugin = "0.2"
 serde = { version = "1", optional = true }
 serde_json = "1"
-urlencoded = "0.5"
+urlencoded = "0.6"
 tempdir = "0.3"
 
 [dependencies.multipart]
 default-features = false
 features = ["server"]
-version = "0.12"
+version = "0.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,6 @@ extern crate serde_json;
 extern crate urlencoded;
 extern crate tempdir;
 
-#[cfg(all(test, feature = "serde"))]
-#[macro_use]
-extern crate maplit;
-
 mod conversion;
 #[cfg(feature = "serde")]
 pub mod serde;


### PR DESCRIPTION
* Update serde to 1.0 (rebased #35)
* Remove maplit (seems to be unused now)
* Update iron deps, bump version

@untitaker this contains all the changes from #35 and #38. If you can merge and release this, that would be great! Then we can close the other PRs.