### PR TITLE
Update dependecies to be compatible with iron 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,19 @@ repository = "https://github.com/iron/params"
 documentation = "http://ironframework.io/doc/params/index.html"
 
 [dependencies]
-bodyparser = "0.6"
-iron = "0.5"
+bodyparser = "0.8"
+iron = "0.6"
 num = "0.1"
 plugin = "0.2"
-serde = { version = "0.9", optional = true }
-serde_json = "0.9"
-urlencoded = "0.5"
+serde = { version = "1.0", optional = true }
+serde_json = "1.0"
+urlencoded = "0.6"
 tempdir = "0.3"
 
 [dependencies.multipart]
 default-features = false
 features = ["server"]
-version = "0.12"
+version = "0.13"
 
 [dev-dependencies]
 maplit = "0.1"


### PR DESCRIPTION
* bodyparser: 0.6 -> 0.8
* iron: 0.5 -> 0.6
* serde: 0.9 -> 1.0
* serde_json: 0.9 -> 1.0
* urlencoded: 0.5 -> 0.6
* multipart: 0.12 -> 0.13

